### PR TITLE
Fixed rendering print preview on PC

### DIFF
--- a/lib/xlsx/parts/workbook.rb
+++ b/lib/xlsx/parts/workbook.rb
@@ -41,6 +41,9 @@ module Xlsx
       def to_xml
         build_standalone_xml do |xml|
           xml.workbook(root_namespaces) {
+            xml.bookViews {
+              xml.workbookView
+            }
             xml.sheets { worksheets.each { |worksheet|
               xml.sheet(
                 "name" => worksheet.name,


### PR DESCRIPTION
This should fix the crash happening with Windows PC when trying to render a print preview. See [here](https://social.msdn.microsoft.com/Forums/office/en-US/54877ee3-25ee-47f8-9731-b1795bd4333a/openxml-excel-file-works-in-excel-2007-openoffice-etc-but-not-in-excel-2010) for the idea behind this change.